### PR TITLE
Fix NaiveDateTime parsing problems

### DIFF
--- a/lib/ecto/adapters/mssql.ex
+++ b/lib/ecto/adapters/mssql.ex
@@ -102,9 +102,9 @@ defmodule Ecto.Adapters.MsSql do
         NaiveDateTime.from_erl({date, {h, m, s}})
       ms > 999999 ->
         rms = Integer.floor_div(ms, 10)
-        NaiveDateTime.from_erl!({date, {h, m, s}}, {rms,  6})
+        NaiveDateTime.from_erl({date, {h, m, s}}, {rms,  6})
       true ->
-        NaiveDateTime.from_erl!({date, {h, m, s}}, {ms,  6})
+        NaiveDateTime.from_erl({date, {h, m, s}}, {ms,  6})
     end
   end
 


### PR DESCRIPTION
Using this branch for MsSQL support, I got the following error triggered by `:naive_datetime` fields:

```
[error] Task #PID<0.940.0> started from #PID<0.936.0> terminating
** (FunctionClauseError) no function clause matching in Ecto.Type.process_loaders/3
    (ecto) lib/ecto/type.ex:796: Ecto.Type.process_loaders([:naive_datetime], ~N[2017-12-19 15:48:04.443333], Ecto.Adapters.MsSql)
    (ecto) lib/ecto/schema/loader.ex:94: Ecto.Schema.Loader.adapter_load/6
    (ecto) lib/ecto/repo/queryable.ex:193: anonymous fn/5 in Ecto.Repo.Queryable.preprocessor/3
    (elixir) lib/enum.ex:1314: Enum."-map/2-lists^map/1-0-"/2
    (ecto) lib/ecto/repo/queryable.ex:152: Ecto.Repo.Queryable.execute/4
    (ecto) lib/ecto/repo/queryable.ex:18: Ecto.Repo.Queryable.all/3
    (ecto) lib/ecto/repo/queryable.ex:66: Ecto.Repo.Queryable.one/3
```

Inspecting this pointed that the function `Ecto.Type.process_loaders/3`, which expects the second argument to be `:error | {:ok, value}`, was instead receiving simply `value` for the second argument, causing it to fail.

Thus, adding an extra matching clause in Ecto could also be a solution, but, since everything is being handled as `{:ok, value}` everywhere (including in the `bool_decode` and `json_decode` functions), this solution seemed more appropriate